### PR TITLE
Hcsr04 ignoreinfspeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # speed_hcsr04
 speed measurement with two ultrasonic sensors
+----------------------------------------------------------------------------------------------------------------
+this updated version just ignores any measurement which lasts than 3 milliseconds!!
+----------------------------------------------------------------------------------------------------------------

--- a/main_code
+++ b/main_code
@@ -83,10 +83,14 @@ void loop()
     Serial.print(cm2);
     Serial.print("Time : ");
     Serial.print(ts2);
-    float billu = ts2 - ts1 - 1.5;
-    speed12 = param/billu;
+    float billu = ts2 - ts1;
+    if(billu<3){
     Serial.println();
-    Serial.print(speed12);
+    }
+    else
+    {speed12 = param/billu;
+    Serial.println();
+    Serial.print(speed12);}
     /*while(1){
       delay(1);
       if(cm2<=20){


### PR DESCRIPTION
This update ignores any measurement that lasts less than 3 milliseconds which should most probably a glitch(due to physical error) and in this way defensive measures will not be taken against such erroraneous high speed!!